### PR TITLE
Added number of tracked orders

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,9 +95,12 @@ function saveOrder(order){
 
 function listenDB(){
     orders.onSnapshot(function(querySnapshot){
+
         //todo: implement docChanges() for better performance when we'll have lots of orders in the list
         $("#orders-table tr").remove();
+        let count = 0;
         querySnapshot.forEach(doc => {
+            count += 1;
             const data = doc.data();
             const formattedOrderNumber = utils.formatOrderNumber(data.order_number);
             const dataOrderId = formattedOrderNumber == "N/A" ? "-1" : formattedOrderNumber;
@@ -113,6 +116,8 @@ function listenDB(){
             }
             $tr.appendTo('#orders-table');
         });
+        $("#tracked-or-loading").text(" orders tracked");
+        $("#order-count").text(count);
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -83,6 +83,10 @@
             <div class="col s12 m10 l8">
                 <div class="card orders">
                     <span class="card-title">Orders shared by the community</span>
+                    <div class="card-subtitle">
+                        <span id="order-count"></span>
+                        <span id="tracked-or-loading"> loading orders...</span>
+                    </div>
                     <table>
                         <thead>
                             <tr>


### PR DESCRIPTION
I don't know anything about Firebase, but as long as you're just going to pull the entire table at once, we can assume that the length of the `querySnapshot` is the same as the number of total items. Likely not the best way forward, but plenty good enough for now.

This addresses https://old.reddit.com/r/boostedboards/comments/8slla8/created_an_app_to_track_orders_for_the_community/e117i1q/ and closes out both issues mentioned in the comment.